### PR TITLE
Missing repos

### DIFF
--- a/omni-default.xml
+++ b/omni-default.xml
@@ -22,14 +22,15 @@
   <project path="packages/apps/DSPManager" name="android_packages_apps_DSPManager" remote="omnirom" revision="android-8.1" />
   <project path="packages/apps/Matlog" name="android_packages_apps_Matlog" remote="omnirom" revision="android-8.1" />
   <project path="packages/apps/MonthCalendarWidget" name="android_packages_apps_MonthCalendarWidget" remote="omnirom" revision="android-8.1" />
-  <project path="packages/apps/OmniChange" name="android_packages_apps_OmniChange" remote="omnirom" revision="android-8.1" />
+  <!--<project path="packages/apps/OmniChange" name="android_packages_apps_OmniChange" remote="omnirom" revision="android-8.1" />
   <project path="packages/apps/OmniClock" name="android_packages_apps_OmniClock" remote="omnirom" revision="android-8.1" />
-  <project path="packages/apps/OmniGears" name="android_packages_apps_OmniGears" remote="omnirom" revision="android-8.1" />
+  <project path="packages/apps/OmniGears" name="android_packages_apps_OmniGears" remote="omnirom" revision="android-8.1" /> -->
   <project path="packages/apps/OmniLib" name="android_packages_apps_OmniLib" remote="omnirom" revision="android-8.1" />
   <project path="packages/apps/OmniBrain" name="android_packages_apps_OmniBrain" remote="omnirom" revision="android-8.1" />
-  <project path="packages/services/OmniJaws" name="android_packages_services_OmniJaws" remote="omnirom" revision="android-8.1" />
+  <!--<project path="packages/services/OmniJaws" name="android_packages_services_OmniJaws" remote="omnirom" revision="android-8.1" />
   <project path="packages/apps/OmniStyle" name="android_packages_apps_OmniStyle" remote="omnirom" revision="android-8.1" />
   <project path="packages/apps/OmniSwitch" name="android_packages_apps_OmniSwitch" remote="omnirom" revision="android-8.1" />
-  <project path="packages/apps/OpenDelta" name="android_packages_apps_OpenDelta" remote="omnirom" revision="android-8.1" />
+  <project path="packages/apps/OpenDelta" name="android_packages_apps_OpenDelta" remote="omnirom" revision="android-8.1" />-->
   <project path="packages/apps/Phonograph" name="android_packages_apps_Phonograph" remote="omnirom" revision="android-8.1" />
 </manifest>
+


### PR DESCRIPTION
Change-Id: Ic1c3fb56404efdea3ca2c148ca3cfd2fb1001222

There are repos listed in the manifest that no longer exist.  I searched for the packages mentioned just in case they've moved, but I didn't find them, so I just commented out the entries for now.   

Addresses a few reports of problems: see Issue #35 